### PR TITLE
Added a release workflow to automate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Build project
-        run: cargo build --verbose
+        run: cargo build --verbose --locked
 
   test:
     name: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version_tag: ${{ steps.tag.outputs.version_tag }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create and push new tag
+        id: tag
+        # https://github.com/rust-cli/meta/issues/33
+        # Thanks ashutoshrishi!
+        run: |
+          VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' Cargo.toml)
+          VERSION="v${VERSION}"
+          echo "Detected version: ${VERSION}"
+          git config --global user.name 'Emil Englesson'
+          git config --global user.email 'englesson.emil@gmail.com'
+          git tag -a ${VERSION} -m ''
+          git push origin refs/tags/${VERSION}
+          echo "::set-output name=version_tag::${VERSION}"
+
+  publish:
+    needs: push-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Publish to crates.io
+        run: cargo publish --token $SECRET_TOKEN
+        env:
+          SECRET_TOKEN: ${{ secrets.CARGO_DROSERA_TOKEN }}
+
+  upload-assets:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          # TODO: Fix duplication of binary name
+          - os: ubuntu-latest
+            artifact_name: drosera # File name of cargo generated binary
+            asset_name: drosera-linux-amd64 # Name of asset uploaded to Github
+          - os: windows-latest
+            artifact_name: drosera.exe # File name of cargo generated binary
+            asset_name: drosera-windows-amd64 # Name of asset uploaded to Github
+          - os: macos-latest
+            artifact_name: drosera # File name of cargo generated binary
+            asset_name: drosera-macos-amd64 # Name of asset uploaded to Github
+
+    name: Upload assets for ${{ matrix.os }}
+    needs: push-tag
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install latest stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Build
+      run: cargo build --release --locked
+    - name: Upload binary to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/${{ matrix.artifact_name }}
+        asset_name: ${{ matrix.asset_name }}
+        tag: ${{needs.push-tag.outputs.version_tag}}


### PR DESCRIPTION
Added a release workflow to automate the release-process.

The workflow consists of three steps. First, the version specified in `Cargo.toml` is extracted and prefixed with a single `v`. This constructed version tag is used as a new tag and pushed back to the repository. 

If this first step is completed successfully two new jobs will start that will run in parallell. One of them will publish a new version to [crates.io](https://crates.io/) and the other one will build binaries for Linux, Windows and Mac and upload them to the newly created tag. This will transform the tag into a release which can be [found here](https://github.com/LimeEng/brainrust/releases), ensuring easy access to the binaries.


Below you can find a flowgraph describing the three steps in the release automation workflow.
```
                                             +-----------------------+
                                             |                       |
                                        +--->|  Publish to crates.io |
                                        |    |                       |
                                        |    +-----------------------+
+-----------------------------+         |
|                             |         |
| Create and push new git tag |---------+
|                             |         |
+-----------------------------+         |
                                        |     +------------------------------------------+
                                        |    |                                           |
                                        +--->|  Upload assets for Linux, Windows and Mac |
                                             |                                           |
                                             +-------------------------------------------+
```

Signed-off-by: Emil Englesson englesson.emil@gmail.com